### PR TITLE
fix(armor): Missing "hat" part definition

### DIFF
--- a/common/src/main/java/net/satisfy/candlelight/client/model/FlowerCrownModel.java
+++ b/common/src/main/java/net/satisfy/candlelight/client/model/FlowerCrownModel.java
@@ -32,7 +32,7 @@ public class FlowerCrownModel<T extends LivingEntity> extends HumanoidModel<T> {
         PartDefinition head = root.addOrReplaceChild("head", CubeListBuilder.create()
                 .texOffs(0, 5).addBox(-4.0F, -8.75F, -4.0F, 8.0F, 4.0F, 8.0F, new CubeDeformation(0.0F)), PartPose.offset(0.0F, 12.75F, 0.0F));
 
-        head.addOrReplaceChild("hat", CubeListBuilder.create(), PartPose.ZERO);
+        root.addOrReplaceChild("hat", CubeListBuilder.create(), PartPose.ZERO);
 
         root.addOrReplaceChild("body", CubeListBuilder.create(), PartPose.ZERO);
         root.addOrReplaceChild("right_arm", CubeListBuilder.create(), PartPose.offset(-5.0F, 2.0F, 0.0F));

--- a/common/src/main/java/net/satisfy/candlelight/client/model/SuitLeggingsModel.java
+++ b/common/src/main/java/net/satisfy/candlelight/client/model/SuitLeggingsModel.java
@@ -32,7 +32,7 @@ public class SuitLeggingsModel<T extends LivingEntity> extends HumanoidModel<T> 
         PartDefinition root = meshDefinition.getRoot();
 
         PartDefinition head = root.addOrReplaceChild("head", CubeListBuilder.create(), PartPose.ZERO);
-        head.addOrReplaceChild("hat", CubeListBuilder.create(), PartPose.ZERO);
+        root.addOrReplaceChild("hat", CubeListBuilder.create(), PartPose.ZERO);
 
         root.addOrReplaceChild("right_arm", CubeListBuilder.create(), PartPose.offset(-5.0F, 2.0F, 0.0F));
         root.addOrReplaceChild("left_arm", CubeListBuilder.create(), PartPose.offset(5.0F, 2.0F, 0.0F));

--- a/common/src/main/java/net/satisfy/candlelight/client/model/TieModel.java
+++ b/common/src/main/java/net/satisfy/candlelight/client/model/TieModel.java
@@ -30,7 +30,7 @@ public class TieModel<T extends LivingEntity> extends HumanoidModel<T> {
         PartDefinition root = meshDefinition.getRoot();
 
         PartDefinition head = root.addOrReplaceChild("head", CubeListBuilder.create(), PartPose.ZERO);
-        head.addOrReplaceChild("hat", CubeListBuilder.create(), PartPose.ZERO);
+        root.addOrReplaceChild("hat", CubeListBuilder.create(), PartPose.ZERO);
 
         root.addOrReplaceChild("right_arm", CubeListBuilder.create(), PartPose.offset(-5.0F, 2.0F, 0.0F));
         root.addOrReplaceChild("left_arm", CubeListBuilder.create(), PartPose.offset(5.0F, 2.0F, 0.0F));


### PR DESCRIPTION
This seems to be a partial fix for https://github.com/Let-s-Do-Collection/Let-s-Do-Collection/issues/971 where rendering the flower crown model crashes the game, as rendering the flower crown with the patch does not crash the game anymore.

However, there are still two issues: 

1. I could not reproduce the problem with the cooking hat where white patches show on armor stands, so no idea on whether that also fixes the original poster's problem
2. The necktie's model seems to be missing. Putting it on the player or an armor stand renders nothing.
